### PR TITLE
Update .gitignore to ignore checkpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,10 @@
 *.tfw
 *.vscode
 *.swp
+*checkpoint*
 *__pycache__*
 *wandb*
+.ckpt
 *.7z
 *lightning_logs*
 *tb_logs*
@@ -20,6 +22,5 @@ logs
 .DS_Store
 **/dataloader/*.pkl
 **/dataloader/*.npy
-.DS_St
 docs/build
 examples/deepfwi-mini-sample


### PR DESCRIPTION
This PR updates the `.gitignore` to not track changes to the saved checkpoints of the pre-trained models.