### PR TITLE
Docker fix shared memory issue in docker-compose

### DIFF
--- a/binder/docker-compose.yml
+++ b/binder/docker-compose.yml
@@ -8,8 +8,9 @@ services:
         - uid=${UID}
         - gid=${GID}
       context: ../
-      shm_size: '10gb'
+      shm_size: '2gb'
       dockerfile: docker/Dockerfile
+    shm_size: '2gb' #this is the maximum memory provided by mybinder
     ports:
       - "8888:8888"
     init: true

--- a/docker/README.md
+++ b/docker/README.md
@@ -39,5 +39,5 @@ In the last command, replace `$USER` with the value you set to `USER` in the `.e
 
 You can now access the JupyterLab on `localhost:8080` with all the goodness of GPUs for training, testing and inference.
 
-**Note**: If you run into issues with shared memory while performing inference or training, use the `--shm-size` flag in `docker run` or the run time `shm_size` argument in `docker-compose` to increase the shared memory allocated to Docker.
+**Note**: If you run into issues with shared memory while performing inference or training, use the `--shm-size` flag in `docker run` or the run time `shm_size` argument in `docker-compose` to increase the shared memory allocated to Docker. You can also set `--ipc=host` to alleviate any shared memory issues in PyTorch worker pids.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -39,5 +39,5 @@ In the last command, replace `$USER` with the value you set to `USER` in the `.e
 
 You can now access the JupyterLab on `localhost:8080` with all the goodness of GPUs for training, testing and inference.
 
-**Note**: If you run into issues with shared memory while performing inference or training, use the `--shm-size` flag in `docker run` or `shm_size` argument in `docker-compose` to increase the shared memory allocated to Docker.
+**Note**: If you run into issues with shared memory while performing inference or training, use the `--shm-size` flag in `docker run` or the run time `shm_size` argument in `docker-compose` to increase the shared memory allocated to Docker.
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,8 +8,9 @@ services:
         - uid=${UID}
         - gid=100
       context: ../
-      shm_size: '10gb'
+      shm_size: '4gb' #shared memory for build
       dockerfile: docker/Dockerfile
+    shm_size: '10gb' #shared memory for run
     ports:
       - "8080:8888"
     volumes:


### PR DESCRIPTION
# What
docker-compose support for increased shared memory

# Why
docker-compose recipe didn't correctly allocate shared memory to container during run time

# How
add `shm_size:  '10gb'` to post-build
add note about `--ipc=host`