### PR TITLE
bump pytorch-lightning

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -31,6 +31,6 @@ dependencies:
   - pip:
     - gsutil==4.52
     - netcdf4==1.5.3
-    - pytorch_lightning==0.9.0rc12
+    - pytorch-lightning==0.9.0
     - sphinx-autoapi==1.4.0
     - wandb==0.8.36


### PR DESCRIPTION
# What
Fix #25 

# Why
`pytorch-lightning==0.9.0rc12` moved to stable and release candidates were removed from `pip`

# How
Bump `pytorch-lightning` to `0.9.0` under pip dependencies