### PR TITLE
Update target variable options

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ For reading geospatial datasets, we use [`xarray`](http://xarray.pydata.org/en/s
     -cb_loss False                          Use Class-Balanced loss with the supplied beta parameter [Bool/float]
     -chronological_split False              Do chronological train-test split in the specified ratio [Bool/float]
     -model unet_tapered                     Model to use: unet, unet_downsampled, unet_snipped, unet_tapered, unet_interpolated [str]
-    -out fwi_reanalysis                     Output data for training: fwi_forecast or fwi_reanalysis [str]
+    -out fwi_reanalysis                     Output data for training: gfas_frp or fwi_reanalysis [str]
     -smos_input False                       Use soil-moisture input data [Bool]
     -forecast-dir ${FORECAST_DIR}           Directory containing forecast data. Alternatively set $FORECAST_DIR [str]
     -forcings-dir ${FORCINGS_DIR}           Directory containing forcings data. Alternatively set $FORCINGS_DIR [str]

--- a/src/train.py
+++ b/src/train.py
@@ -264,18 +264,6 @@ def set_hparams(hparams):
         )
         if hparams.boxcox and not (type(hparams.boxcox) == type(bool)):
             hparams.boxcox = BOX_COX_LAMBDA
-    elif hparams.out == "fwi_forecast":
-        from data.consts.forecast_stats import (
-            FORECAST_FWI_MAD,
-            FORECAST_FWI_MEAN,
-            FORECAST_FWI_VAR,
-        )
-
-        hparams.out_mean, hparams.out_mad, hparams.out_var = (
-            FORECAST_FWI_MEAN,
-            FORECAST_FWI_MAD,
-            FORECAST_FWI_VAR,
-        )
 
     if hparams.cb_loss and hparams.out == "fwi_reanalysis":
         from data.consts.reanalysis_freq import bin_centers, freq


### PR DESCRIPTION
- We predict FWI-Reanalysis and FRP, not FWI-forecast. This PR removes the (unused) support to use FWI-forecast as an output that was introduced in the very beginning of the project.
- Corresponding README update