### PR TITLE
Support for plotting results summary from wandb json log

### DIFF
--- a/src/plot.py
+++ b/src/plot.py
@@ -353,11 +353,12 @@ def main(argv):
     try:
         opts, args = getopt.getopt(argv, "hf:i:o:", ["file=", "in-days=", "out-days="])
     except getopt.GetoptError:
-        print("test.py -f <file> -i <in-days> -o <out-days>")
+        print("plot.py -f <file> -i <in-days> -o <out-days>")
         sys.exit(2)
     for opt, arg in opts:
         if opt == "-h":
-            print("test.py -f <file> -i <in-days> -o <out-days>")
+            print("plot.py -f <file> -i <in-days> -o <out-days>")
+            sys.exit(2)
         elif opt in ("-f", "--file"):
             file_name = str(arg)
         elif opt in ("-i", "--in-days"):
@@ -369,4 +370,7 @@ def main(argv):
 
 
 if __name__ == "__main__":
-    main(sys.argv[1:])
+    if len(sys.argv) < 2:
+        print("plot.py -f <file> -i <in-days> -o <out-days>")
+    else:
+        main(sys.argv[1:])

--- a/src/plot.py
+++ b/src/plot.py
@@ -215,15 +215,11 @@ def single_day_plot(result, hparams, m, benchmark=None):
             )
         )
 
-    # bar labels not needed, since it is not legible
-    #     for rect in rect_list:
-    #         autolabel(rect, ax, width)
-
     if benchmark:
         ax.legend()
 
     fig.tight_layout()
-    file_name = time.strftime("%Y%m%d-%H%M%S")
+    file_name = m + "_" + time.strftime("%Y%m%d-%H%M%S")
 
     plt.savefig(file_name, dpi=600, bbox_inches="tight")
 
@@ -313,20 +309,19 @@ def multi_day_plot(result, hparams, benchmark=None, m="acc"):
         handles, labels, bbox_to_anchor=(1, 1), loc="upper left", fontsize="x-small"
     )
 
-    # bar labels not needed, since it is not legible
-    #     for rect in rects:
-    #         autolabel(rect, ax, width)
-
     fig.tight_layout()
 
-    file_name = time.strftime("%Y%m%d-%H%M%S")
+    file_name = m + "_" + time.strftime("%Y%m%d-%H%M%S")
 
     plt.savefig(file_name, dpi=600, bbox_inches="tight")
 
 
-def plot(**kwargs) -> None:
+def plot(results_file, **kwargs) -> None:
     """
     Make plots. The kwargs are equivalent to commandline args
+
+    :param results_file: json file of results
+    :type results_file: str
     """
     plt.rcParams["figure.figsize"] = [20, 10]
     plt.rcParams["font.size"] = 18
@@ -337,7 +332,7 @@ def plot(**kwargs) -> None:
 
     hparams = Namespace(**get_hparams(**kwargs))
 
-    result, results_summary = read_json("results.json")
+    result, results_summary = read_json(results_file)
 
     for m in ["acc", "mse", "mae"]:
         if hparams.out_days > 1:
@@ -361,4 +356,4 @@ config = dict(
     out_days=14,
 )
 
-plot(**config, benchmark=False)
+plot("results.json", **config, benchmark=False)

--- a/src/plot.py
+++ b/src/plot.py
@@ -4,6 +4,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 from argparse import Namespace
 import warnings
+import sys
+import getopt
 
 
 def str2num(s):
@@ -337,23 +339,34 @@ def plot(results_file, **kwargs) -> None:
     for m in ["acc", "mse", "mae"]:
         if hparams.out_days > 1:
             multi_day_plot(
-                result=result[m],
-                hparams=hparams,
-                m=m,
-                benchmark=None,
+                result=result[m], hparams=hparams, m=m, benchmark=None,
             )
         else:
             single_day_plot(
-                result=result[m],
-                hparams=hparams,
-                m=m,
-                benchmark=None,
+                result=result[m], hparams=hparams, m=m, benchmark=None,
             )
 
 
-config = dict(
-    in_days=4,
-    out_days=14,
-)
+def main(argv):
+    in_days = 4
+    out_days = 10
+    try:
+        opts, args = getopt.getopt(argv, "hf:i:o:", ["file=", "in-days=", "out-days="])
+    except getopt.GetoptError:
+        print("test.py -f <file> -i <in-days> -o <out-days>")
+        sys.exit(2)
+    for opt, arg in opts:
+        if opt == "-h":
+            print("test.py -f <file> -i <in-days> -o <out-days>")
+        elif opt in ("-f", "--file"):
+            file_name = str(arg)
+        elif opt in ("-i", "--in-days"):
+            in_days = int(arg)
+        else:
+            out_days = int(arg)
+    config = dict(in_days=in_days, out_days=out_days,)
+    plot(results_file=file_name, **config, benchmark=False)
 
-plot("results.json", **config, benchmark=False)
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/src/plot.py
+++ b/src/plot.py
@@ -1,0 +1,87 @@
+import json
+from pprint import pprint
+
+
+def read_json(results_file: str) -> tuple:
+    """
+    Read and process a json results summary
+
+    :param results_file: path to json results
+    :type results_file: str
+    """
+    with open(results_file, "r") as res_file:
+        # the results file is a json where each record
+        # is of either binned or general
+        # "mae_11.2_21.3_9": 9.765079498291016 OR
+        # "val_acc_4": 0.6305782198905945,
+        results = json.load(res_file)
+
+        results_summary = {}
+
+        acc_list = []
+        mae_list = []
+        mse_list = []
+
+        metric_list_dict = {}
+        metric_list_dict["acc"] = acc_list
+        metric_list_dict["mae"] = mae_list
+        metric_list_dict["mse"] = mse_list
+
+        # first make a dict with keys acc, mae, mse
+        # where the values are list of dicts
+        # each dict being an individual record
+        # storing the bin, day and value
+
+        for key, value in results.items():
+            key_split = key.split("_")
+            if len(key_split) == 4:
+                record = {}
+                record["bin"] = (float(key_split[1]), float(key_split[2]))
+                record["day"] = int(key_split[3])
+                record["val"] = value
+
+                metric_list_dict[key_split[0]].append(record)
+
+            else:
+                results_summary[key] = value
+        # Use make_dict() function to transform the dict of list of dicts
+        # to dicts all the way down
+        return (make_dict(metric_list_dict), results_summary)
+
+
+def make_dict(metric_list_dict: dict) -> dict:
+    """
+    Convert dict of list of dicts to dicts of dicts of dicts
+
+    :param metric_list_dict: dict of list of dicts
+    :type metric_list_dict: dict
+    """
+
+    # Use any one of acc, mae, mse to get bins
+    # assumes all three have the same metrics
+
+    acc_metrics = metric_list_dict["acc"]
+    bins_list = []
+    for record in acc_metrics:
+        temp_bin = record["bin"]
+        if temp_bin not in bins_list:
+            bins_list.append(temp_bin)
+
+    binned_metrics = {}
+
+    for key, value in metric_list_dict.items():
+        metrics = {}
+        for bin in bins_list:
+            # create empty dicts for every bin
+            metrics[bin] = {}
+        for record in value:
+            # add data to the empty dicts
+            metrics[record["bin"]][record["day"]] = record["val"]
+        binned_metrics[key] = metrics
+
+    return binned_metrics
+
+
+metric_list_dict, results_summary = read_json("results.json")
+
+pprint(metric_list_dict)

--- a/src/plot.py
+++ b/src/plot.py
@@ -1,5 +1,70 @@
 import json
-from pprint import pprint
+import time
+import matplotlib.pyplot as plt
+import numpy as np
+from argparse import Namespace
+import warnings
+
+
+def str2num(s):
+    """
+    Converts parameter strings to appropriate types.
+
+    :param s: Parameter value
+    :type s: str
+    :return: Appropriately converted value
+    :rtype: Varying
+    """
+    if isinstance(s, bool):
+        return s
+    s = str(s)
+    if "," in s:
+        return [str2num(i) for i in s.split(",")]
+    if "." in s or "e-" in s:
+        try:
+            return float(s)
+        except:
+            pass
+    elif s.isdigit():
+        return int(s)
+    elif s.lower() == "inf":
+        return float("inf")
+    elif s.lower() == "none":
+        return None
+    else:
+        if s.lower() == "true":
+            return True
+        elif s.lower() == "false":
+            return False
+    return s
+
+
+def get_hparams(
+    in_days: ("Number of input days [int]", "option") = 2,
+    out_days: ("Number of output days [int]", "option") = 1,
+    binned: (
+        "Show the extended metrics for supplied comma separated binned FWI value range "
+        "(e.g. 0,15,70) [Bool/list]",
+        "option",
+    ) = "0,5.2,11.2,21.3,38.0,50",
+    case_study: (
+        "The case-study region to use for inference: australia, california, portugal,"
+        " siberia, chile, uk [Bool/str]",
+        "option",
+    ) = False,
+    benchmark: (
+        "Benchmark the FWI-Forecast data against FWI-Reanalysis [Bool]",
+        "option",
+    ) = False,
+):
+    """
+    Process and print the dictionary of project wide arguments.
+
+    :return: Dictionary containing configuration options.
+    :rtype: dict
+    """
+    config_dict = {k: str2num(v) for k, v in locals().items()}
+    return config_dict
 
 
 def read_json(results_file: str) -> tuple:
@@ -8,6 +73,8 @@ def read_json(results_file: str) -> tuple:
 
     :param results_file: path to json results
     :type results_file: str
+    :return: binned metrics and results summary
+    :rtype: tuple
     """
     with open(results_file, "r") as res_file:
         # the results file is a json where each record
@@ -55,6 +122,8 @@ def make_dict(metric_list_dict: dict) -> dict:
 
     :param metric_list_dict: dict of list of dicts
     :type metric_list_dict: dict
+    :return: dict of dict of dicts
+    :rtype: dict
     """
 
     # Use any one of acc, mae, mse to get bins
@@ -82,6 +151,214 @@ def make_dict(metric_list_dict: dict) -> dict:
     return binned_metrics
 
 
-metric_list_dict, results_summary = read_json("results.json")
+def single_day_plot(result, hparams, m, benchmark=None):
+    """
+    Plot mteric results for single day output.
 
-pprint(metric_list_dict)
+    :param result: Model inference result dictionary
+    :type result: dict
+    :param hparams: Hyperparamters
+    :type hparams: Namespace
+    :param benchmark: Benchmark result dictionary, defaults to None
+    :type benchmark: dict, optional
+    :param m: metric
+    :type m: str
+    """
+    bin_range = hparams.binned
+    bin_labels = [
+        f"({bin_range[i]}, {bin_range[i+1]}]"
+        for i in range(len(bin_range))
+        if i < len(bin_range) - 1
+    ]
+    bin_labels.append(f"({bin_range[-1]}, inf)")
+
+    fwi_levels = ["V. Low", "Low", "Mod", "High", "V. High", "Extreme"]
+    bin_labels = [bin_labels[i] + "\n" + fwi_levels[i] for i in range(len(bin_labels))]
+
+    xlab = "FWI Level"
+    # The label locations
+    x = np.arange(len(bin_labels))
+    # The width of the bars
+    width = 0.7 / (3 if benchmark else 2)
+    title = f"{hparams.in_days} Day Input // 1 Day Prediction (Global)"
+    fig, ax = plt.subplots()
+
+    # Add some text for labels, title and custom x-axis tick labels, etc.
+    ylabel = {
+        "acc": "Accuracy",
+        "mae": "Mean absolute error",
+        "mse": "Mean squared error",
+    }
+    ax.set_ylabel(ylabel[m])
+    ax.set_xlabel(xlab)
+    ax.set_title(title)
+    ax.set_xticks(x)
+    ax.set_xticklabels(bin_labels)
+
+    num_groups = 2 if benchmark else 1
+
+    rect_list = []
+    preds = [x[0] for x in result.values()]
+    rect_list.append(
+        ax.bar(
+            x - width * num_groups / 2 + width * 1 / 2, preds, width, label="deepFWI"
+        )
+    )
+    if benchmark:
+        bench = [x[0] for x in benchmark.values()]
+        rect_list.append(
+            ax.bar(
+                x - width * num_groups / 2 + width * 1 / 2 + width * 1,
+                bench,
+                width,
+                label="FWI-Forecast",
+            )
+        )
+
+    # bar labels not needed, since it is not legible
+    #     for rect in rect_list:
+    #         autolabel(rect, ax, width)
+
+    if benchmark:
+        ax.legend()
+
+    fig.tight_layout()
+    file_name = time.strftime("%Y%m%d-%H%M%S")
+
+    plt.savefig(file_name, dpi=600, bbox_inches="tight")
+
+
+def multi_day_plot(result, hparams, benchmark=None, m="acc"):
+    """
+    Plot mteric results for single day output.
+
+    :param result: Model inference result dictionary
+    :type result: dict
+    :param hparams: Hyperparamters
+    :type hparams: Namespace
+    :param benchmark: Benchmark result dictionary, defaults to None
+    :type benchmark: dict, optional
+    :param m: metric
+    :type m: str, optional
+    """
+    bin_range = hparams.binned
+
+    fwi_levels = ["V. Low", "Low", "Mod", "High", "V. High", "Extreme"]
+
+    bin_labels = [
+        f"({bin_range[i]}, {bin_range[i+1]}]"
+        for i in range(len(bin_range))
+        if i < len(bin_range) - 1
+    ]
+    bin_labels.append(f"({bin_range[-1]}, inf)")
+
+    bin_labels = [bin_labels[i] + " " + fwi_levels[i] for i in range(len(bin_labels))]
+
+    labels = list(range(len(list(result.values())[0])))
+
+    width = 1 / (len(bin_range) + 1)
+    x = np.arange(len(list(result.values())[0]))
+
+    preds = [list(x.values()) for x in result.values()]
+
+    fig, ax = plt.subplots()
+    rects = []
+
+    color = ["#008000", "#FFFF00", "#FFA500", "#FF0000", "#654321", "#000000"]
+    for i in range(len(bin_range)):
+        rects.append(
+            ax.bar(
+                x - width * (len(bin_range) + 1) / 2 + (i + 1) * width,
+                [x for x in preds[i]],
+                width,
+                label=bin_labels[i],
+                align="center",
+                color=color[i],
+            )
+        )
+
+    if benchmark:
+        bench = [list(x.values()) for x in benchmark.values()]
+        for i in range(len(bin_range)):
+            ax.plot(
+                x,
+                bench[i],
+                color=color[i],
+                marker="o",
+                zorder=3,
+                label=None if i else r"$\mathbf{FWI-Forecast}$",
+            )
+
+    ax.plot([], [], " ", label=r"$\mathbf{deepFWI}$")
+
+    ylabel = {
+        "acc": "Accuracy in %",
+        "mae": "Mean absolute error (A.U.)",
+        "mse": "Mean squared error (A.U.)",
+    }
+    ax.set_ylabel(ylabel[m])
+    ax.set_title(
+        f"{hparams.in_days} Day Input // {hparams.out_days} Day Prediction "
+        f"({hparams.case_study if hparams.case_study else 'Global'})"
+    )
+
+    ax.set_xticks(x)
+    ax.set_xlabel("Day of FWI Prediction")
+    ax.set_xticklabels(labels)
+    ax.legend()
+    handles, labels = ax.get_legend_handles_labels()
+    handles.append("_")
+    labels.append("FWI-forecast")
+    ax.legend(
+        handles, labels, bbox_to_anchor=(1, 1), loc="upper left", fontsize="x-small"
+    )
+
+    # bar labels not needed, since it is not legible
+    #     for rect in rects:
+    #         autolabel(rect, ax, width)
+
+    fig.tight_layout()
+
+    file_name = time.strftime("%Y%m%d-%H%M%S")
+
+    plt.savefig(file_name, dpi=600, bbox_inches="tight")
+
+
+def plot(**kwargs) -> None:
+    """
+    Make plots. The kwargs are equivalent to commandline args
+    """
+    plt.rcParams["figure.figsize"] = [20, 10]
+    plt.rcParams["font.size"] = 18
+    plt.rcParams["legend.fontsize"] = "large"
+    plt.rcParams["figure.titlesize"] = "medium"
+
+    warnings.filterwarnings("ignore")
+
+    hparams = Namespace(**get_hparams(**kwargs))
+
+    result, results_summary = read_json("results.json")
+
+    for m in ["acc", "mse", "mae"]:
+        if hparams.out_days > 1:
+            multi_day_plot(
+                result=result[m],
+                hparams=hparams,
+                m=m,
+                benchmark=None,
+            )
+        else:
+            single_day_plot(
+                result=result[m],
+                hparams=hparams,
+                m=m,
+                benchmark=None,
+            )
+
+
+config = dict(
+    in_days=4,
+    out_days=14,
+)
+
+plot(**config, benchmark=False)


### PR DESCRIPTION
Add support for generating plots from `json` file logged in `wandb`.

### Usage:
```bash
cd src
python plot.py -f <file> -i <in-days> -o <out-days>
```

OR

```bash
cd src
python plot.py --file=<file> --in-days=<in-days> --out-days=<out-days> 
```

The `json` file from `wandb` looks like below:
```json
{
  "mae_7": 6.902379035949707,
  "mse_7": 161.7944793701172,
  "mae_0_5.2_12": 3.149575471878052,
  "mae_0_5.2_11": 3.1354246139526367,
  "mae_0_5.2_3": 2.7353785037994385,
  "mae_0_5.2_1": 2.0346179008483887,
  "mae_0_5.2_5": 2.73897123336792,
  "mae_0_5.2_13": 3.519204378128052,
  "mae_0_5.2_7": 3.1210639476776123,
  "mae_0_5.2_9": 2.8523571491241455,
.
.
.
  "acc_21.3_38.0_12": 0.5104139447212219,
  "acc_21.3_38.0_6": 0.5155320167541504,
  "acc_21.3_38.0_13": 0.4988612234592438,
  "mse_50_inf_3": 483.4289245605469,
  "acc_50_inf_12": 0.38585364818573,
  "mae_5": 6.408102989196777,
  "mse_3": 117.29159545898438,
  "mse_10": 129.6900634765625,
  "mse_13": 167.86300659179688,
  "acc_5.2_11.2_4": 0.9075574278831482,
  "acc_5.2_11.2_8": 0.8843024373054504,
  "acc_5.2_11.2_5": 0.9044651389122008,
  "acc_5.2_11.2_1": 0.929454505443573,
  "acc_5.2_11.2_12": 0.8586841225624084,
.
.
.
}
```

The output plots look as below:
![acc_20201021-144834](https://user-images.githubusercontent.com/11018951/96737201-f98fe280-13ef-11eb-997c-51ff53545fdb.png)
![mae_20201021-144843](https://user-images.githubusercontent.com/11018951/96737205-fb59a600-13ef-11eb-85b4-922c076f4255.png)
![mse_20201021-144838](https://user-images.githubusercontent.com/11018951/96737209-fc8ad300-13ef-11eb-92d1-b609226494c4.png)
